### PR TITLE
feat: Add Xphere Mainnet

### DIFF
--- a/_data/chains/eip155-20250217.json
+++ b/_data/chains/eip155-20250217.json
@@ -1,0 +1,23 @@
+{
+  "name": "Xphere Mainnet",
+  "chain": "XPHERE",
+  "features": [{ "name": "EIP155" }, { "name": "EIP1559" }],
+  "rpc": ["https://en-bkk.x-phere.com"],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Xphere",
+    "symbol": "XP",
+    "decimals": 18
+  },
+  "infoURL": "https://x-phere.com/",
+  "shortName": "xp",
+  "chainId": 20250217,
+  "networkId": 20250217,
+  "explorers": [
+    {
+      "name": "Tamsa",
+      "url": "https://xp.tamsa.io",
+      "standard": "EIP3091"
+    }
+  ]
+}


### PR DESCRIPTION
Title: Add Xphere Mainnet (chainId: 20250217)

Description:
feat: Add Xphere Mainnet network information

This PR adds the Xphere Mainnet network configuration with the following details:
- Chain ID: 20250217
- Network ID: 20250217
- Native Currency: XP
- RPC Endpoint: https://en-bkk.x-phere.com
- Explorer: https://xp.tamsa.io

The network supports:
- EIP155 (Chain ID in transaction signing)
- EIP1559 (Fee market change)

Network information has been verified and is currently active.